### PR TITLE
Updated threejs to r163, added explicit stencil: true value in renderer params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@types/three": "^0.146.0",
+        "@types/three": "^0.163.0",
         "dat.gui": "^0.7.9",
-        "three": "^0.148.0"
+        "three": "^0.163.0"
       },
       "devDependencies": {
         "npm-run-all": "^4.1.5",
@@ -94,6 +94,11 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.1",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.1.tgz",
+      "integrity": "sha512-ZpboH7pCPPeyBWKf8c7TJswtCEQObFo3bOBYalm99NzZarATALYCo5OhbCa/n4RQyJyHfhkdx+hNrdL5ByFYDw=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -255,12 +260,21 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.3.tgz",
+      "integrity": "sha512-pXNfAD3KHOdif9EQXZ9deK82HVNaXP5ZIF5RP2QG6OQFNTaY2YIetfrE9t528vEreGQvEPRDDc8muaoYeK0SxQ=="
+    },
     "node_modules/@types/three": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.146.0.tgz",
-      "integrity": "sha512-75AgysUrIvTCB054eQa2pDVFurfeFW8CrMQjpzjt3yHBfuuknoSvvsESd/3EhQxPrz9si3+P0wiDUVsWUlljfA==",
+      "version": "0.163.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.163.0.tgz",
+      "integrity": "sha512-uIdDhsXRpQiBUkflBS/i1l3JX14fW6Ot9csed60nfbZNXHDTRsnV2xnTVwXcgbvTiboAR4IW+t+lTL5f1rqIqA==",
       "dependencies": {
-        "@types/webxr": "*"
+        "@tweenjs/tween.js": "~23.1.1",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
       }
     },
     "node_modules/@types/webxr": {
@@ -1445,6 +1459,11 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2416,6 +2435,11 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -3713,9 +3737,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.148.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.148.0.tgz",
-      "integrity": "sha512-8uzVV+qhTPi0bOFs/3te3RW6hb3urL8jYEl6irjCWo/l6sr8MPNMcClFev/MMYeIxr0gmDcoXTy/8LXh/LXkfw=="
+      "version": "0.163.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.163.0.tgz",
+      "integrity": "sha512-HlMgCb2TF/dTLRtknBnjUTsR8FsDqBY43itYop2+Zg822I+Kd0Ua2vs8CvfBVefXkBdNDrLMoRTGCIIpfCuDew=="
     },
     "node_modules/thunky": {
       "version": "1.1.0",
@@ -4517,6 +4541,11 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "@tweenjs/tween.js": {
+      "version": "23.1.1",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.1.tgz",
+      "integrity": "sha512-ZpboH7pCPPeyBWKf8c7TJswtCEQObFo3bOBYalm99NzZarATALYCo5OhbCa/n4RQyJyHfhkdx+hNrdL5ByFYDw=="
+    },
     "@types/body-parser": {
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -4677,12 +4706,21 @@
         "@types/node": "*"
       }
     },
+    "@types/stats.js": {
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.3.tgz",
+      "integrity": "sha512-pXNfAD3KHOdif9EQXZ9deK82HVNaXP5ZIF5RP2QG6OQFNTaY2YIetfrE9t528vEreGQvEPRDDc8muaoYeK0SxQ=="
+    },
     "@types/three": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.146.0.tgz",
-      "integrity": "sha512-75AgysUrIvTCB054eQa2pDVFurfeFW8CrMQjpzjt3yHBfuuknoSvvsESd/3EhQxPrz9si3+P0wiDUVsWUlljfA==",
+      "version": "0.163.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.163.0.tgz",
+      "integrity": "sha512-uIdDhsXRpQiBUkflBS/i1l3JX14fW6Ot9csed60nfbZNXHDTRsnV2xnTVwXcgbvTiboAR4IW+t+lTL5f1rqIqA==",
       "requires": {
-        "@types/webxr": "*"
+        "@tweenjs/tween.js": "~23.1.1",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
       }
     },
     "@types/webxr": {
@@ -5626,6 +5664,11 @@
         "websocket-driver": ">=0.5.1"
       }
     },
+    "fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -6326,6 +6369,11 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="
     },
     "methods": {
       "version": "1.1.2",
@@ -7295,9 +7343,9 @@
       }
     },
     "three": {
-      "version": "0.148.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.148.0.tgz",
-      "integrity": "sha512-8uzVV+qhTPi0bOFs/3te3RW6hb3urL8jYEl6irjCWo/l6sr8MPNMcClFev/MMYeIxr0gmDcoXTy/8LXh/LXkfw=="
+      "version": "0.163.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.163.0.tgz",
+      "integrity": "sha512-HlMgCb2TF/dTLRtknBnjUTsR8FsDqBY43itYop2+Zg822I+Kd0Ua2vs8CvfBVefXkBdNDrLMoRTGCIIpfCuDew=="
     },
     "thunky": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "webpack-dev-server": "4.11.1"
   },
   "dependencies": {
-    "@types/three": "^0.146.0",
+    "@types/three": "^0.163.0",
     "dat.gui": "^0.7.9",
-    "three": "^0.148.0"
+    "three": "^0.163.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ dirLight.shadow.mapSize.height = 1024;
 scene.add(dirLight);
 
 // RENDERER
-const renderer = new THREE.WebGLRenderer({ antialias: true });
+const renderer = new THREE.WebGLRenderer({ antialias: true, stencil: true });
 renderer.shadowMap.enabled = true;
 renderer.setPixelRatio(window.devicePixelRatio);
 renderer.setSize(window.innerWidth, window.innerHeight);

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ camera.position.set(4, 5, 4);
 // LIGHTS
 scene.add(new THREE.AmbientLight(0xffffff, 0.9));
 
-const dirLight = new THREE.DirectionalLight(0xffffff, 1);
+const dirLight = new THREE.DirectionalLight(0xffffff, 10);
 dirLight.position.set(5, 10, 7.5);
 dirLight.castShadow = true;
 dirLight.shadow.camera.right = 2;
@@ -105,7 +105,7 @@ function initCube() {
     boxBorderMat.stencilRef = 0;
     boxBorderMat.stencilFunc = THREE.EqualStencilFunc;
     const boxBorderGeom = new THREE.BoxGeometry();
-    scene.add(new THREE.Mesh(boxBorderGeom, boxBorderMat));
+    // scene.add(new THREE.Mesh(boxBorderGeom, boxBorderMat));
 }
 
 function initPlanes () {


### PR DESCRIPTION
This updates the version of threejs to the latest as of 12th April 2024 - r163, and fixes an issue where the previous code would only render a black cube. I fixed it by providing an explicit `stencil: true` value to the renderer parameters.

The lighting is a bit different now as a result of other changes since r148, but it's preferable to it not working.